### PR TITLE
pc_demo: support building by CMake

### DIFF
--- a/pc_demo/CMakeLists.txt
+++ b/pc_demo/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.16)
+
+project(UBootSerialUpdateDemoPrj VERSION 1.0.0 LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+include_directories(./utils ./)
+
+find_package(Qt6 REQUIRED COMPONENTS Core SerialPort Widgets)
+qt_standard_project_setup()
+
+add_executable(UBootSerialUpdateDemo
+    comm/physerialthread.cpp
+    main.cpp
+    updatethread.cpp
+    utils/utils.cpp
+    mainwindow.cpp
+)
+
+target_link_libraries(UBootSerialUpdateDemo PRIVATE Qt6::Core Qt6::SerialPort Qt6::Widgets)

--- a/pc_demo/README.md
+++ b/pc_demo/README.md
@@ -2,3 +2,20 @@
 
 用于演示自定义 uboot 升级流程 
 
+# Build using CMake
+
+```
+mkdir build
+cd build
+cmake ../
+make
+```
+
+## Install Qt on mac
+User needs to install qt6 on mac, the easy way to install is:
+
+```
+brew install qt
+```
+
+As of Sep 2022, the installed version is Qt6 on the mac.

--- a/pc_demo/comm/physerialthread.h
+++ b/pc_demo/comm/physerialthread.h
@@ -2,7 +2,7 @@
 #define PHYSERIALTHREAD_H
 
 #include "utils/blockingqueue.h"
-#include <QSerialPort>
+#include <QtSerialPort/QSerialPort>
 #include <QThread>
 
 class PhySerialThread : public QThread

--- a/pc_demo/main.cpp
+++ b/pc_demo/main.cpp
@@ -3,7 +3,7 @@
 #include <vector>
 #include <QByteArray>
 
-#include <QApplication>
+#include <QtWidgets/QApplication>
 
 #include <QDateTime>
 #include <QFile>

--- a/pc_demo/mainwindow.cpp
+++ b/pc_demo/mainwindow.cpp
@@ -1,10 +1,10 @@
 #include "mainwindow.h"
 #include "ui_mainwindow.h"
 #include <QByteArray>
-#include <QFileDialog>
-#include <QMessageBox>
-#include <QSerialPort>
-#include <QSerialPortInfo>
+#include <QtWidgets/QFileDialog>
+#include <QtWidgets/QMessageBox>
+#include <QtSerialPort/QSerialPort>
+#include <QtSerialPort/QSerialPortInfo>
 
 MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWindow)
 {

--- a/pc_demo/mainwindow.h
+++ b/pc_demo/mainwindow.h
@@ -4,7 +4,7 @@
 #include "updatethread.h"
 #include <memory>
 #include <QByteArray>
-#include <QMainWindow>
+#include <QtWidgets/QMainWindow>
 
 QT_BEGIN_NAMESPACE
 namespace Ui {


### PR DESCRIPTION
Now on Mac (tested) or in Linux (not tested), we could use cmake to build the pc_demo application. It supports Qt6. Refer to README.md for details.